### PR TITLE
[DONT MERGE - Experimental]  test execution in docker image

### DIFF
--- a/src/agents/Evaluator.ts
+++ b/src/agents/Evaluator.ts
@@ -45,7 +45,7 @@ export class Evaluator {
         });
     }
 
-    public async depurateCommand(rawCommand: string) {
+    public depurateCommand(rawCommand: string) {
         const commandWithoutStopwords = stopwords.reduce((code, stopword) => {
             return code.split(stopword).join("");
         }, rawCommand);
@@ -73,6 +73,7 @@ export class Evaluator {
         const rawCommand = result.text;
 
         const clearCommand = this.depurateCommand(rawCommand);
+        console.log('DEBUG: clearCommand', clearCommand);
         const syncExec = promisify(exec);
 
         try {

--- a/src/agents/Evaluator.ts
+++ b/src/agents/Evaluator.ts
@@ -3,7 +3,8 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 // LangChain
-import { LLMChain, PromptTemplate } from "langchain";
+import { LLMChain } from "langchain/chains";
+import { PromptTemplate } from "langchain/prompts";
 import { OpenAI } from "langchain/llms/openai";
 
 //Relative imports
@@ -18,71 +19,71 @@ import { VectorMemory } from "../memory";
  * check for common code smells
  */
 export class Evaluator {
-  private chain?: LLMChain;
+    private chain?: LLMChain;
 
-  /**
-   * To be called right after creating the instance.
-   * Prepares the evaluation LLM chain
-   */
-  public async init() {
-    const memory = new VectorMemory();
-    await memory.init();
-    const { openAIApiKey } = await SecretsManager.getInstance().getSecrets();
-    const model = new OpenAI({ openAIApiKey });
-    const prompt =
-      PromptTemplate.fromTemplate(`You are an AI assistant designed to output test execution commands without any other information.
+    /**
+     * To be called right after creating the instance.
+     * Prepares the evaluation LLM chain
+     */
+    public async init() {
+        const memory = new VectorMemory();
+        await memory.init();
+        const { openAIApiKey } = await SecretsManager.getInstance().getSecrets();
+        const model = new OpenAI({ openAIApiKey });
+        const prompt =
+            PromptTemplate.fromTemplate(`You are an AI assistant designed to output test execution commands without any other information.
 
                 Context:
                 {history}
 
                 Current task: {input}`);
 
-    this.chain = new LLMChain({
-      llm: model,
-      prompt,
-      memory: memory.getStore(),
-    });
-  }
-
-  public async depurateCommand(rawCommand: string) {
-    const commandWithoutStopwords = stopwords.reduce((code, stopword) => {
-      return code.split(stopword).join("");
-    }, rawCommand);
-    return commandWithoutStopwords.replace(/\s+/g, " ").trim();
-  }
-
-  /**
-   * Asks the LLM the appropiate command to run the test.
-   *
-   * Spawns a subprocess to run the test and registers the output
-   */
-  public async executeTest(testPath: string): Promise<void> {
-    if (!this.chain) {
-      throw new Error(
-        "Please call Evaluator.init() before Evaluator.executeTest()"
-      );
+        this.chain = new LLMChain({
+            llm: model,
+            prompt,
+            memory: memory.getStore(),
+        });
     }
 
-    const task = `Tell me the begining of the command to run the tests on this project`;
-
-    const result = await this.chain.call({
-      input: task,
-    });
-
-    const rawCommand = result.text;
-
-    const clearCommand = this.depurateCommand(rawCommand);
-    const syncExec = promisify(exec);
-
-    try {
-      const { stdout, stderr } = await syncExec(`${clearCommand} ${testPath}`);
-      console.log("stdout", stdout);
-      console.log("stderr", stderr);
-    } catch (e) {
-      // invalid command
-      // tell the LLM the command failed and ask it for a new command
-      // maybe in a small (controlled) loop until the command success?
-      console.log(e);
+    public async depurateCommand(rawCommand: string) {
+        const commandWithoutStopwords = stopwords.reduce((code, stopword) => {
+            return code.split(stopword).join("");
+        }, rawCommand);
+        return commandWithoutStopwords.replace(/\s+/g, " ").trim();
     }
-  }
+
+    /**
+     * Asks the LLM the appropiate command to run the test.
+     *
+     * Spawns a subprocess to run the test and registers the output
+     */
+    public async executeTest(testPath: string): Promise<void> {
+        if (!this.chain) {
+            throw new Error(
+                "Please call Evaluator.init() before Evaluator.executeTest()"
+            );
+        }
+
+        const task = `Tell me the begining of the command to run the tests on this project`;
+
+        const result = await this.chain.call({
+            input: task,
+        });
+
+        const rawCommand = result.text;
+
+        const clearCommand = this.depurateCommand(rawCommand);
+        const syncExec = promisify(exec);
+
+        try {
+            const { stdout, stderr } = await syncExec(`${clearCommand} ${testPath}`);
+            console.log("stdout", stdout);
+            console.log("stderr", stderr);
+        } catch (e) {
+            // invalid command
+            // tell the LLM the command failed and ask it for a new command
+            // maybe in a small (controlled) loop until the command success?
+            console.log(e);
+        }
+    }
 }

--- a/src/agents/Evaluator.ts
+++ b/src/agents/Evaluator.ts
@@ -1,0 +1,78 @@
+// LangChain
+import { LLMChain, PromptTemplate } from "langchain";
+import { OpenAI } from "langchain/llms/openai";
+
+//Relative imports
+import { SecretsManager, stopwords } from "../utils";
+import { VectorMemory } from "../memory";
+
+// External imports
+import { exec } from "child_process";
+import { promisify } from "util";
+import * as vscode from "vscode";
+
+export class Evaluator {
+
+    private memory?: VectorMemory;
+    private syncExec = promisify(exec);
+
+    private runCommandInTerminal(command: string) {
+        let terminal = vscode.window.terminals.find(terminal => terminal.name === "TestWizard");
+
+        if (!terminal) {
+            terminal = vscode.window.createTerminal("TestWizard");
+        }
+        terminal.show();
+        terminal.sendText(command);
+    }
+
+    public async executeTest(testPath: string): Promise<void> {
+        this.memory = new VectorMemory();
+        await this.memory.init();
+        console.log('Executing test!')
+        const { openAIApiKey } = await SecretsManager.getInstance().getSecrets();
+        const model = new OpenAI({ openAIApiKey });
+        const prompt =
+            PromptTemplate.fromTemplate(`You are an AI assistant designed to output test execution commands without any other information.
+
+                Context:
+                {history}
+
+                Current task: {input}`);
+
+        const chain = new LLMChain({
+            llm: model,
+            prompt,
+            memory: this.memory.getStore(),
+        });
+        const task = `Tell me the begining of the command to run the tests on this project`;
+
+        const result = await chain.call({
+            input: task,
+        });
+
+        console.log('DEBUG CHAIN RESPONSE -> ', result.text);
+        const command = result.text;
+        const commandWithoutStopwords = stopwords.reduce((code, stopword) => {
+            return code.split(stopword).join("");
+        }, command);
+        console.log('COMMAND TO RUN', `${commandWithoutStopwords} ${testPath}`)
+        const cleanCommand = commandWithoutStopwords.replace(/\s+/g, ' ').trim();
+        this.runCommandInTerminal(`./node_modules/.bin/${cleanCommand} ${testPath}`);
+
+        /* const { stdout, stderr } = await this.syncExec(`npm install ${commandWithoutStopwords} && ${commandWithoutStopwords} ${testPath}`); */
+
+        /* await this.memory.getStore()?.saveContext(
+            {
+              input: `I'm using ${commandWithoutStopwords} to run the tests on this project`,
+            },
+            { output: "ok" }
+        ); */
+
+        /* console.log('testOutPut -> ', stdout);
+        if (stderr) {
+            console.log('testError -> ', stderr);
+        } */
+    }
+
+}

--- a/src/agents/Publisher.ts
+++ b/src/agents/Publisher.ts
@@ -2,6 +2,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { promisify } from "util";
+import { WorkspaceFolder } from "vscode";
 
 export class Publisher {
   public async outputTest(directory: string, filename: string, code: string): Promise<string> {
@@ -18,6 +19,16 @@ export class Publisher {
       } else {
         throw e;
       }
+    }
+  }
+  public async outputDockerfile(directory: WorkspaceFolder, content: string): Promise<string> {
+    const write = promisify(fs.writeFile);
+    try {
+      const dockerfilePath = path.join(directory.uri.fsPath, 'Dockerfile');
+      await write(dockerfilePath, content);
+      return dockerfilePath;
+    } catch (e) {
+      throw e;
     }
   }
 }

--- a/src/agents/Publisher.ts
+++ b/src/agents/Publisher.ts
@@ -4,11 +4,13 @@ import * as path from "path";
 import { promisify } from "util";
 
 export class Publisher {
-  public async outputTest(directory: string, filename: string, code: string) {
+  public async outputTest(directory: string, filename: string, code: string): Promise<string> {
     const write = promisify(fs.writeFile);
-    const fileExtension = ".spec.ts";
+    const fileExtension = ".spec.ts"; // TODO: Make this smarter, could be asking the LLM.
     try {
-      write(path.join(directory, `${filename}${fileExtension}`), code);
+      const testPath = path.join(directory, `${filename}${fileExtension}`);
+      write(testPath, code);
+      return testPath; // I assumed file extension will be dinamic when multilanguage support is added. So I return the path to the test file instead of generating in extension.ts
     } catch (e) {
       if ((e as Error).message.includes("EEXIST")) {
         // TODO: Retry with a different name

--- a/src/agents/Publisher.ts
+++ b/src/agents/Publisher.ts
@@ -9,7 +9,7 @@ export class Publisher {
     const fileExtension = ".spec.ts"; // TODO: Make this smarter, could be asking the LLM.
     try {
       const testPath = path.join(directory, `${filename}${fileExtension}`);
-      write(testPath, code);
+      await write(testPath, code);
       return testPath; // I assumed file extension will be dinamic when multilanguage support is added. So I return the path to the test file instead of generating in extension.ts
     } catch (e) {
       if ((e as Error).message.includes("EEXIST")) {

--- a/src/agents/TestGenerator.ts
+++ b/src/agents/TestGenerator.ts
@@ -4,7 +4,7 @@ import { PromptTemplate } from "langchain/prompts";
 import { LLMChain } from "langchain/chains";
 
 // Relative imports
-import { SecretsManager } from "../utils";
+import { SecretsManager, stopwords } from "../utils";
 import { VectorMemory } from "../memory";
 
 /**
@@ -68,7 +68,6 @@ export class TestGenerator {
 
     const code = result.text;
     // We need to cleanup unwanted preffixes on the response
-    const stopwords = ["output:", "text:"];
     const codeWithoutStopwords = stopwords.reduce((code, stopword) => {
       return code.split(stopword).join("");
     }, code);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
 import { TestGenerator } from "./agents/TestGenerator";
 import PineconeDB from "./database";
 import { Publisher } from "./agents/Publisher";
-
+import { Evaluator } from "./agents/Evaluator";
 /**
  * Pinecone index creation can take up to
  * 1 minute. We need to run this process
@@ -119,13 +119,21 @@ export async function activate(context: vscode.ExtensionContext) {
                   const { filePath, fileBaseName } = getPathComponents(
                     editor.document.fileName
                   );
-                  await publisher.outputTest(
+                  const testPath = await publisher.outputTest(
                     filePath,
                     fileBaseName,
                     generatedTest
                   );
                   vscode.window.showInformationMessage(
                     "New test generated successfully!"
+                  );
+                  vscode.window.showInformationMessage(
+                    "Evaluating new test!"
+                  );
+                  const evaluator = new Evaluator
+                  await evaluator.executeTest(testPath);
+                  vscode.window.showInformationMessage(
+                    "Test has been evaluated!"
                   );
                   resolve();
                 });
@@ -147,4 +155,4 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-export function deactivate() {}
+export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
                   // Evaluate the new test
                   const evaluator = new Evaluator
                   await evaluator.init()
-                  await evaluator.executeTest(testPath);
+                  await evaluator.executeTest(testPath, folder);
                   vscode.window.showInformationMessage(
                     "Test has been evaluated!"
                   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,9 @@ export async function activate(context: vscode.ExtensionContext) {
                   vscode.window.showInformationMessage(
                     "Evaluating new test!"
                   );
+                  // Evaluate the new test
                   const evaluator = new Evaluator
+                  await evaluator.init()
                   await evaluator.executeTest(testPath);
                   vscode.window.showInformationMessage(
                     "Test has been evaluated!"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,6 +22,8 @@ export const errorMessages = {
 
 export const acceptedLanguages = ["typescript", "javascript", "python", "ruby"];
 
+export const stopwords = ["output:", "text:", "Answer:"];
+
 export function getPathComponents(fullPath: string) {
   const filePathComponents = fullPath.split(sep);
   const fileName = filePathComponents[filePathComponents.length - 1];
@@ -31,3 +33,4 @@ export function getPathComponents(fullPath: string) {
   const fileBaseName = fileName.split(".")[0];
   return { filePath, fileBaseName };
 }
+


### PR DESCRIPTION
Dirty branch to try and execute the tests from within a docker container built in users machine:
    * Might feel intrusive from an users POV
    * Its only a experiment that I want to leave registered in case we go that way
    
I am resuming the work around execution from a subprocess finding a workaround to install dependencies without running 'npm' The error triggering is: `npm ERR! Tracker "idealTree" already exists` and this is what our friend [GPT said about it](https://chat.openai.com/share/24d504cc-c0a4-4263-a6d6-b48d194f572b)